### PR TITLE
feat: redraw bubbles on resize

### DIFF
--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as d3 from 'd3';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 type Item = {
   name: string;
@@ -12,14 +12,19 @@ type Item = {
 type Node = Item & { x: number; y: number; r: number };
 
 export default function BubbleChart({ data }: { data: Item[] }) {
-  const width = 1100;
-  const height = 560;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dims, setDims] = useState({ width: 1100, height: 560 });
+  const bottomGap = 20;
   const [nodes, setNodes] = useState<Node[]>([]);
 
   const radii = useMemo(() => {
-    const maxAbs = d3.max(data, d => Math.abs(d.change24hPct)) || 1;
-    return d3.scaleSqrt().domain([0, maxAbs]).range([26, 90]);
-  }, [data]);
+    const maxAbs = d3.max(data, (d: Item) => Math.abs(d.change24hPct)) || 1;
+    const scale = dims.width / 1100;
+    return d3
+      .scaleSqrt()
+      .domain([0, maxAbs])
+      .range([26 * scale, 90 * scale]);
+  }, [data, dims.width]);
 
   useEffect(() => {
     const init = data.map<Node>((d) => ({
@@ -29,24 +34,59 @@ export default function BubbleChart({ data }: { data: Item[] }) {
       r: radii(Math.abs(d.change24hPct)),
     }));
     setNodes(init);
-  }, [data, radii]);
+  }, [data]);
+
+  useEffect(() => {
+    setNodes(ns => {
+      ns.forEach(n => {
+        n.r = radii(Math.abs(n.change24hPct));
+      });
+      return [...ns];
+    });
+  }, [radii]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const rect = containerRef.current?.getBoundingClientRect();
+      const width = rect?.width || window.innerWidth;
+      const top = rect?.top || 0;
+      const height = window.innerHeight - top - bottomGap;
+      setDims({ width, height });
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    setNodes(ns =>
+      ns.map(n => ({
+        ...n,
+        x: Math.max(n.r, Math.min(dims.width - n.r, n.x || 0)),
+        y: Math.max(n.r, Math.min(dims.height - n.r, n.y || 0)),
+      }))
+    );
+  }, [dims.width, dims.height]);
 
   useEffect(() => {
     if (!nodes.length) return;
-    const sim = d3
-      .forceSimulation(nodes as d3.SimulationNodeDatum[])
-      .force('charge', d3.forceManyBody().strength(2))
-      .force('center', d3.forceCenter(width / 2, height / 2))
-      .force('collision', d3.forceCollide<Node>().radius(d => d.r + 4).iterations(2))
+    const sim = (d3 as any)
+      .forceSimulation(nodes as any)
+      .force('charge', (d3 as any).forceManyBody().strength(2))
+      .force('center', (d3 as any).forceCenter(dims.width / 2, dims.height / 2))
+      .force('collision', (d3 as any)
+        .forceCollide()
+        .radius((d: Node) => d.r + 4)
+        .iterations(2))
       .on('tick', () => {
         nodes.forEach(n => {
-          n.x = Math.max(n.r, Math.min(width - n.r, n.x || 0));
-          n.y = Math.max(n.r, Math.min(height - n.r, n.y || 0));
+          n.x = Math.max(n.r, Math.min(dims.width - n.r, n.x || 0));
+          n.y = Math.max(n.r, Math.min(dims.height - n.r, n.y || 0));
         });
         setNodes([...nodes]);
       });
     return () => void sim.stop();
-  }, [nodes.length]);
+  }, [nodes.length, dims.width, dims.height]);
 
   const color = (v: number) =>
     v > 0
@@ -57,12 +97,12 @@ export default function BubbleChart({ data }: { data: Item[] }) {
 
   return (
     <div
+      ref={containerRef}
       style={{
         position: 'relative',
-        width,
-        maxWidth: '100%',
-        height,
-        margin: '0 auto',
+        width: '100%',
+        height: dims.height,
+        margin: `0 auto ${bottomGap}px`,
         borderRadius: 20,
         background: '#0f1115',
         boxShadow: '0 0 0 1px rgba(255,255,255,0.04) inset',

--- a/types/d3.d.ts
+++ b/types/d3.d.ts
@@ -1,0 +1,1 @@
+declare module 'd3';


### PR DESCRIPTION
## Summary
- adjust bubble chart dimensions using a container ref
- clamp and rerun simulation to keep bubbles within new bounds on resize
- scale bubble radii with container width so they shrink proportionally
- stretch chart height to the viewport minus a small bottom gap