### PR TITLE
Expand bubble chart to full page height

### DIFF
--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -69,27 +69,6 @@ export default function BubbleChart({ data }: { data: Item[] }) {
   }, [dims.width, dims.height]);
 
   useEffect(() => {
-    const handleResize = () => {
-      const width = containerRef.current?.clientWidth || window.innerWidth;
-      const height = width * (560 / 1100);
-      setDims({ width, height });
-    };
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  useEffect(() => {
-    setNodes(ns =>
-      ns.map(n => ({
-        ...n,
-        x: Math.max(n.r, Math.min(dims.width - n.r, n.x || 0)),
-        y: Math.max(n.r, Math.min(dims.height - n.r, n.y || 0)),
-      }))
-    );
-  }, [dims.width, dims.height]);
-
-  useEffect(() => {
     if (!nodes.length) return;
     const sim = (d3 as any)
       .forceSimulation(nodes as any)
@@ -123,7 +102,7 @@ export default function BubbleChart({ data }: { data: Item[] }) {
         position: 'relative',
         width: '100%',
         height: dims.height,
-        margin: `0 auto ${bottomGap}px`,
+        margin: '0 auto',
         borderRadius: 20,
         background: '#0f1115',
         boxShadow: '0 0 0 1px rgba(255,255,255,0.04) inset',


### PR DESCRIPTION
## Summary
- allow bubble chart to grow to the bottom of the page with a small gap
- remove redundant resize logic keeping chart height fixed

## Testing
- `npm run build` *(fails: Can't resolve 'pino-pretty', but build completed with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a3c9f98832c803256e077d5ab90