### PR TITLE
Load NFT data from CSV

### DIFF
--- a/app/api/collections/route.ts
+++ b/app/api/collections/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { csvParse } from 'd3-dsv';
+
+export async function GET() {
+  const csvPath = path.join(process.cwd(), 'backend', 'filtered_collections.csv');
+  const text = fs.readFileSync(csvPath, 'utf-8');
+  const records = csvParse(text);
+  const data = records.map((rec: any) => {
+    const info = JSON.parse(rec.general_info);
+    const stats = JSON.parse(rec.stats);
+    const floor = stats.total.floor_price as number;
+    const avg = stats.total.average_price as number;
+    const change = avg ? ((floor - avg) / avg) * 100 : 0;
+    return {
+      name: info.name as string,
+      image: info.image_url as string,
+      floorEth: floor,
+      change24hPct: Math.round(change * 100) / 100,
+      link: info.opensea_url as string | undefined,
+    };
+  });
+  return NextResponse.json(data);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useMiniKit } from '@coinbase/onchainkit/minikit';
 import BubbleChart from '@/components/BubbleChart';
 
@@ -7,27 +7,20 @@ type Coll = {
   name: string;
   floorEth: number;
   change24hPct: number;
+  image: string;
   link?: string;
 };
 
-const DATA: Coll[] = [
-  { name: 'Kemonokaki', floorEth: 0.03, change24hPct: -10, link: '#' },
-  { name: 'Black Mirror Experience: Smile Pass', floorEth: 0.02, change24hPct: +6.9, link: '#' },
-  { name: 'BasePaint', floorEth: 0.009, change24hPct: +2.7, link: '#' },
-  { name: 'Bankr Club', floorEth: 0.11, change24hPct: -11.1, link: '#' },
-  { name: 'Capy Friends', floorEth: 0.11, change24hPct: -29.2, link: '#' },
-  { name: 'onchain gaias', floorEth: 0.05, change24hPct: -1.8, link: '#' },
-  { name: 'Farcaster Pro OG', floorEth: 0.03, change24hPct: +7.5, link: '#' },
-  { name: 're:generates', floorEth: 0.02, change24hPct: +1.7, link: '#' },
-  { name: 'based punks', floorEth: 0.07, change24hPct: -1.8, link: '#' },
-  { name: 'OK COMPUTERS', floorEth: 0.02, change24hPct: -7.5, link: '#' },
-  { name: 'Based Ape Gang', floorEth: 0.03, change24hPct: -0.7, link: '#' },
-  { name: 'No-Punks', floorEth: 0.009, change24hPct: +10.4, link: '#' },
-];
-
 export default function Page() {
   const { setFrameReady, isFrameReady } = useMiniKit();
+  const [data, setData] = useState<Coll[]>([]);
   useEffect(() => { if (!isFrameReady) setFrameReady(); }, [isFrameReady, setFrameReady]);
+  useEffect(() => {
+    fetch('/api/collections')
+      .then(res => res.json())
+      .then(setData)
+      .catch(() => setData([]));
+  }, []);
   return (
     <main style={{ minHeight: '100svh', background: '#0b0b0c', color: 'white' }}>
       <div style={{ maxWidth: 1100, margin: '0 auto', padding: '24px' }}>
@@ -35,8 +28,8 @@ export default function Page() {
         <p style={{ opacity: 0.7, marginTop: 6, marginBottom: 20 }}>
           Размер — |Δ%| за сутки; цвет: зелёный = рост, красный = падение; подпись — имя и floor (ETH).
         </p>
-        <BubbleChart data={DATA} />
-        <footer style={{ opacity: 0.6, marginTop: 16, fontSize: 12 }}>Mock data. Для продакшна подставьте свой источник по API.</footer>
+        <BubbleChart data={data} />
+        <footer style={{ opacity: 0.6, marginTop: 16, fontSize: 12 }}>Данные из backend/filtered_collections.csv.</footer>
       </div>
     </main>
   );

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -6,6 +6,7 @@ type Item = {
   name: string;
   floorEth: number;
   change24hPct: number;
+  image?: string;
   link?: string;
 };
 
@@ -125,10 +126,28 @@ export default function BubbleChart({ data }: { data: Item[] }) {
               width: n.r * 2,
               height: n.r * 2,
               ['--bubble-color' as any]: borderColor(pct),
+              backgroundImage: n.image ? `url(${n.image})` : undefined,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              overflow: 'hidden',
             } as CSSProperties}
             title={`${n.name}\nFloor: ${n.floorEth} ETH\n24h: ${pct > 0 ? '+' : ''}${pct}%`}
           >
-            <div className="bubble-content" style={{ padding: 8, lineHeight: 1.1 }}>
+            <div
+              className="bubble-content"
+              style={{
+                padding: 8,
+                lineHeight: 1.1,
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: 'rgba(0,0,0,0.45)',
+                borderRadius: '50%',
+              }}
+            >
               <strong
                 style={{ fontSize: Math.max(11, Math.min(16, n.r / 4.5)), fontWeight: 700, textShadow: '0 2px 6px rgba(0,0,0,.45)' }}
               >

--- a/types/d3-dsv.d.ts
+++ b/types/d3-dsv.d.ts
@@ -1,0 +1,1 @@
+declare module 'd3-dsv';


### PR DESCRIPTION
## Summary
- add API route to parse `backend/filtered_collections.csv` and expose NFT name, image, floor price and computed change
- fetch collection data on the landing page and feed it to the bubble chart
- show collection images inside bubbles