### PR TITLE
Fix bubble drag lingering after mouse release

### DIFF
--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -27,6 +27,7 @@ export default function BubbleChart({ data }: { data: Item[] }) {
   const draggingRef = useRef(false);
   const holdRef = useRef(false);
   const holdTimer = useRef<number | undefined>(undefined);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
   const [hovered, setHovered] = useState<Node | null>(null);
 
   const radii = useMemo(() => {
@@ -118,6 +119,7 @@ export default function BubbleChart({ data }: { data: Item[] }) {
 
   const startDrag = (e: React.PointerEvent, idx: number) => {
     e.preventDefault();
+    dragCleanupRef.current?.();
     draggingRef.current = false;
     holdRef.current = false;
     holdTimer.current = window.setTimeout(() => {
@@ -129,6 +131,10 @@ export default function BubbleChart({ data }: { data: Item[] }) {
     (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
 
     const move = (ev: PointerEvent) => {
+      if (!ev.buttons) {
+        up();
+        return;
+      }
       draggingRef.current = true;
       setNodes(ns => {
         const n = ns[idx];
@@ -147,8 +153,10 @@ export default function BubbleChart({ data }: { data: Item[] }) {
       });
     };
 
-    const up = () => {
+    function up() {
       window.clearTimeout(holdTimer.current);
+      draggingRef.current = false;
+      holdRef.current = false;
       (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
       setNodes(ns => {
         const n = ns[idx];
@@ -162,12 +170,14 @@ export default function BubbleChart({ data }: { data: Item[] }) {
       window.removeEventListener('pointermove', move);
       window.removeEventListener('pointerup', up);
       window.removeEventListener('pointercancel', up);
-    };
+      dragCleanupRef.current = null;
+    }
 
     simRef.current?.alphaTarget(0.3).restart();
     window.addEventListener('pointermove', move);
     window.addEventListener('pointerup', up);
     window.addEventListener('pointercancel', up);
+    dragCleanupRef.current = up;
   };
 
   const sparkline = useMemo(() => {


### PR DESCRIPTION
## Summary
- ensure previous bubble's drag handlers are cleaned up before starting a new drag
- reset dragging and hold state on pointer release to prevent bubbles reattaching to cursor

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (warnings about missing optional dependency `pino-pretty`)


------
https://chatgpt.com/codex/tasks/task_e_68bc9fde42f4832cbce4f73929e2722e